### PR TITLE
Hide the slider-handle instead of deleting it.

### DIFF
--- a/src/multirange-slider.coffee
+++ b/src/multirange-slider.coffee
@@ -97,9 +97,6 @@ angular.module("at.multirange-slider")
         )
         nextRange()?.adjustWidth(handle.width()/2 + 'px')
 
-    if scope.$last
-      element.remove()
-
     startX = 0
     startPleft = startPright = 0
 

--- a/src/multirange-slider.css
+++ b/src/multirange-slider.css
@@ -31,6 +31,10 @@
   background: #ddd;
 }
 
+.at-multirange-slider .slider-range:last-child .slider-handle{
+    display: none;
+}
+
 .at-multirange-slider .slider-label {
   text-align: center;
   padding-top: .25em;


### PR DESCRIPTION
I noticed that if the model array has only one element and then you add another, the handles don't appear because the original code deleted the handle. I've changed it to only hide the handle using css. That way when you add a second element, the handle for the first range appears.
